### PR TITLE
1.2.2

### DIFF
--- a/GameData/PayToPlay/PayToPlay.version
+++ b/GameData/PayToPlay/PayToPlay.version
@@ -2,7 +2,7 @@
   "NAME": "PayToPlay",
   "URL": "https://raw.githubusercontent.com/DarthPointer/PayToPlay/master/GameData/PayToPlay/PlayToPlay.version",
   "DOWNLOAD": "https://github.com/DarthPointer/PayToPlay/releases",
-  "VERSION": {"MAJOR": 1, "MINOR": 2, "PATCH": 1, "BUILD": 0},
+  "VERSION": {"MAJOR": 1, "MINOR": 2, "PATCH": 2, "BUILD": 0},
   "KSP_VERSION": {"MAJOR": 1, "MINOR": 8, "PATCH": 1},
   "KSP_VERSION_MIN": {"MAJOR": 1, "MINOR": 8, "PATCH": 0},
   "KSP_VERSION_MAX": {"MAJOR": 1, "MINOR": 9, "PATCH": 9}

--- a/GameData/PayToPlay/Support/Kerbalism/ModuleKiller(Kerbalism_3.7_and_lower).txt
+++ b/GameData/PayToPlay/Support/Kerbalism/ModuleKiller(Kerbalism_3.7_and_lower).txt
@@ -1,0 +1,6 @@
+// Rename this into a .cfg one if you use Kerbalism 3.7 or an older version
+
+@PART[*]:HAS[@MODULE[ModuleEngines*],@MODULE[Reliability]]:NEEDS[KerbalismDefault]:FINAL
+{
+	!MODULE[Reliability] {}
+}

--- a/GameData/PayToPlay/Support/Kerbalism/ModuleKiller.cfg
+++ b/GameData/PayToPlay/Support/Kerbalism/ModuleKiller.cfg
@@ -1,4 +1,0 @@
-@PART[*]:HAS[@MODULE[ModuleEngines*],@MODULE[Reliability]]:NEEDS[KerbalismDefault]:FINAL
-{
-	!MODULE[Reliability] {}
-}


### PR DESCRIPTION
Disabled modulekiller for kerbalism support as it is not needed for Kerbalism 3.8+.