### PR TITLE
Fix version file URL property

### DIFF
--- a/GameData/PayToPlay/PayToPlay.version
+++ b/GameData/PayToPlay/PayToPlay.version
@@ -1,6 +1,6 @@
 {
   "NAME": "PayToPlay",
-  "URL": "https://raw.githubusercontent.com/DarthPointer/PayToPlay/master/GameData/PayToPlay/PlayToPlay.version",
+  "URL": "https://github.com/DarthPointer/PayToPlay/raw/master/GameData/PayToPlay/PayToPlay.version",
   "DOWNLOAD": "https://github.com/DarthPointer/PayToPlay/releases",
   "VERSION": {"MAJOR": 1, "MINOR": 2, "PATCH": 2, "BUILD": 0},
   "KSP_VERSION": {"MAJOR": 1, "MINOR": 8, "PATCH": 1},

--- a/GameData/PayToPlay/PayToPlay.version
+++ b/GameData/PayToPlay/PayToPlay.version
@@ -1,6 +1,6 @@
 {
   "NAME": "PayToPlay",
-  "URL": "https://github.com/DarthPointer/PayToPlay/raw/master/GameData/PayToPlay/PayToPlay.version",
+  "URL": "https://raw.githubusercontent.com/DarthPointer/PayToPlay/master/GameData/PayToPlay/PayToPlay.version",
   "DOWNLOAD": "https://github.com/DarthPointer/PayToPlay/releases",
   "VERSION": {"MAJOR": 1, "MINOR": 2, "PATCH": 2, "BUILD": 0},
   "KSP_VERSION": {"MAJOR": 1, "MINOR": 8, "PATCH": 1},


### PR DESCRIPTION
The current URL is a 404.
Now it's fixed.

Noticed while working on KSP-CKAN/NetKAN#7925.
Tagging @DarthPointer since not everyone has GitHub notifications turned on for pull requests.